### PR TITLE
Added build.app to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/[Bb]uild.app/
 /[Ll]ibrary/
 /[Tt]emp/
 /[Oo]bj/


### PR DESCRIPTION
Someone had folder build.app created when running Unity, I added it to gitignore just in case.
