### PR TITLE
Fix attack

### DIFF
--- a/Assets/Prefabs/Projectiles/Projectile.prefab
+++ b/Assets/Prefabs/Projectiles/Projectile.prefab
@@ -1,21 +1,10 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1001 &100100000
-Prefab:
-  m_ObjectHideFlags: 1
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications: []
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 0}
-  m_RootGameObject: {fileID: 1000012462945698}
-  m_IsPrefabParent: 1
 --- !u!1 &1000012462945698
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_PrefabInternal: {fileID: 0}
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 4000010338026084}
@@ -32,7 +21,7 @@ GameObject:
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1000012462945698}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.17, y: 18.01, z: -0.27}
@@ -45,7 +34,7 @@ Transform:
 Rigidbody:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1000012462945698}
   serializedVersion: 2
   m_Mass: 1
@@ -60,7 +49,7 @@ Rigidbody:
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
+  m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1000012462945698}
   m_Enabled: 1
   m_EditorHideFlags: 0

--- a/Assets/Prefabs/Towers/Tower.prefab
+++ b/Assets/Prefabs/Towers/Tower.prefab
@@ -65,6 +65,23 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000013890915426
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000012275614808}
+  - 114: {fileID: 114000010443219952}
+  - 54: {fileID: 54000011435968816}
+  m_Layer: 8
+  m_Name: Projectile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!4 &4000011410470234
 Transform:
   m_ObjectHideFlags: 1
@@ -72,12 +89,13 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000011397538348}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalPosition: {x: 39.1, y: -0.35, z: -3.1}
+  m_LocalScale: {x: 1, y: 1, z: 1.0000004}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 4000013186379108}
   - {fileID: 4000011863964682}
+  - {fileID: 4000012275614808}
   m_Father: {fileID: 0}
   m_RootOrder: 0
 --- !u!4 &4000011863964682
@@ -87,12 +105,25 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000012882011190}
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: -1, y: 12, z: 0}
+  m_LocalPosition: {x: 75, y: 0, z: 95}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011410470234}
   m_RootOrder: 1
+--- !u!4 &4000012275614808
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013890915426}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.17, y: 18.01, z: -0.27}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 4000011410470234}
+  m_RootOrder: 2
 --- !u!4 &4000013186379108
 Transform:
   m_ObjectHideFlags: 1
@@ -155,6 +186,21 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 1
   m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!54 &54000011435968816
+Rigidbody:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013890915426}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
@@ -261,6 +307,17 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
+--- !u!114 &114000010443219952
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000013890915426}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4afcdf504eb034419143c4ba1751568, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114000010655950502
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -298,7 +355,7 @@ CapsuleCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
-  m_Radius: 15
+  m_Radius: 100
   m_Height: 30
   m_Direction: 2
   m_Center: {x: 1, y: 0, z: 7}

--- a/Assets/Scripts/Model/Building.cs
+++ b/Assets/Scripts/Model/Building.cs
@@ -71,5 +71,9 @@ public class Building : MonoBehaviour, CanUpgrade, CanReceiveDamage
         return this.totalHealth - this.currentHealth;
     }
 
+	public bool isDead()
+	{
+		return this == null;
+	}
 
 }

--- a/Assets/Scripts/Model/Building.cs
+++ b/Assets/Scripts/Model/Building.cs
@@ -67,9 +67,7 @@ public class Building : MonoBehaviour, CanUpgrade, CanReceiveDamage
         return this.totalHealth - this.currentHealth;
     }
 
-	public bool isDead ()
-	{
-		return this == null;
+	public float getCurrentHealth(){
+		return this.currentHealth;
 	}
-
 }

--- a/Assets/Scripts/Model/Building.cs
+++ b/Assets/Scripts/Model/Building.cs
@@ -51,27 +51,23 @@ public class Building : MonoBehaviour, CanUpgrade, CanReceiveDamage
 	}
 
 	// Receive damage from a projectile (shot by weapon)
-	public bool ReceiveDamage (Projectile proj)
+	public void ReceiveDamage (Projectile proj)
 	{
 		this.currentHealth -= proj.getDamage();
 		Debug.Log ("Building's currentHealth: " + this.currentHealth);
 		//Debug.Log ("BUILDING DAMAGED by HP: " + proj.getDamage());
 
-		if (this.currentHealth <= 0.0)
-		{
-            GameController.instance.notifyDeath(this);
-			return true;
-		} else {
-			return false;
+		if (this.currentHealth <= 0.0) {
+			GameController.instance.notifyDeath (this);
 		}
 	}
 
-    public float getMissingHealth()
+    public float getMissingHealth ()
     {
         return this.totalHealth - this.currentHealth;
     }
 
-	public bool isDead()
+	public bool isDead ()
 	{
 		return this == null;
 	}

--- a/Assets/Scripts/Model/CanReceiveDamage.cs
+++ b/Assets/Scripts/Model/CanReceiveDamage.cs
@@ -4,4 +4,5 @@ using System.Collections;
 public interface CanReceiveDamage
 {
 	bool ReceiveDamage (Projectile proj);
+	bool isDead ();
 }

--- a/Assets/Scripts/Model/CanReceiveDamage.cs
+++ b/Assets/Scripts/Model/CanReceiveDamage.cs
@@ -4,5 +4,5 @@ using System.Collections;
 public interface CanReceiveDamage
 {
 	void ReceiveDamage (Projectile proj);
-	bool isDead ();
+	float getCurrentHealth ();
 }

--- a/Assets/Scripts/Model/CanReceiveDamage.cs
+++ b/Assets/Scripts/Model/CanReceiveDamage.cs
@@ -3,6 +3,6 @@ using System.Collections;
 
 public interface CanReceiveDamage
 {
-	bool ReceiveDamage (Projectile proj);
+	void ReceiveDamage (Projectile proj);
 	bool isDead ();
 }

--- a/Assets/Scripts/Model/Projectile.cs
+++ b/Assets/Scripts/Model/Projectile.cs
@@ -28,8 +28,8 @@ public class Projectile : MonoBehaviour
 	}
 
 	// Shoot the projectile to the target
-	public bool Shoot(){
-		return this.target.ReceiveDamage (this);
+	public void Shoot(){
+		this.target.ReceiveDamage (this);
 	}
 
 	// Get the projectile damage (defined by weapon)

--- a/Assets/Scripts/Model/Unit.cs
+++ b/Assets/Scripts/Model/Unit.cs
@@ -37,25 +37,16 @@ public class Unit : MonoBehaviour, CanReceiveDamage
 	}
 
 	// Receive damage from a projectile (shot by weapon)
-	public bool ReceiveDamage (Projectile proj)
+	public void ReceiveDamage (Projectile proj)
 	{
-		if (this.isDead()) {
-			Debug.Log ("DEAD ON RECEIVE DAMAGE");
-			return true;
-		} else {
-			this.currentHealth -= proj.getDamage ();
-			Debug.Log ("Unit " + this.name + " currentHealth: " + this.currentHealth);
-			//Debug.Log("UNIT DAMAGED by HP: " + proj.getDamage());
+		this.currentHealth -= proj.getDamage ();
+		Debug.Log ("Unit " + this.name + " currentHealth: " + this.currentHealth);
+		//Debug.Log("UNIT DAMAGED by HP: " + proj.getDamage());
 
-			if (this.currentHealth <= 0.0f) {
-				GameController.instance.notifyDeath (this); // Tell controller I'm dead
-				Destroy (this.gameObject);
-				Debug.Log ("Unit " + this.name + " is dead");
-				return true;
-			} else {
-				return false;
-			}
-		}
+		if (this.currentHealth <= 0.0f) {
+			GameController.instance.notifyDeath (this); // Tell controller I'm dead
+			Destroy (this.gameObject);
+		} 
 	}
 
 	// If enemy enters the range of attack

--- a/Assets/Scripts/Model/Unit.cs
+++ b/Assets/Scripts/Model/Unit.cs
@@ -67,10 +67,8 @@ public class Unit : MonoBehaviour, CanReceiveDamage
 			this.weapon.removeTarget (col.gameObject.GetComponent<CanReceiveDamage> ());
 		}
 	}
-
-	public bool isDead ()
-	{
-		return this == null;
-	} 
 		
+	public float getCurrentHealth(){
+		return this.currentHealth;
+	}
 }

--- a/Assets/Scripts/Model/Unit.cs
+++ b/Assets/Scripts/Model/Unit.cs
@@ -39,18 +39,22 @@ public class Unit : MonoBehaviour, CanReceiveDamage
 	// Receive damage from a projectile (shot by weapon)
 	public bool ReceiveDamage (Projectile proj)
 	{
-		this.currentHealth -= proj.getDamage();
-		Debug.Log ("Unit " + this.name +" currentHealth: " + this.currentHealth);
-		//Debug.Log("UNIT DAMAGED by HP: " + proj.getDamage());
-
-		if (this.currentHealth <= 0.0f)
-		{
-            GameController.instance.notifyDeath(this); // Tell controller I'm dead
-            Destroy (this.gameObject);
-			Debug.Log ("Unit " + this.name + " is dead");
+		if (this.isDead()) {
+			Debug.Log ("DEAD ON RECEIVE DAMAGE");
 			return true;
 		} else {
-			return false;
+			this.currentHealth -= proj.getDamage ();
+			Debug.Log ("Unit " + this.name + " currentHealth: " + this.currentHealth);
+			//Debug.Log("UNIT DAMAGED by HP: " + proj.getDamage());
+
+			if (this.currentHealth <= 0.0f) {
+				GameController.instance.notifyDeath (this); // Tell controller I'm dead
+				Destroy (this.gameObject);
+				Debug.Log ("Unit " + this.name + " is dead");
+				return true;
+			} else {
+				return false;
+			}
 		}
 	}
 
@@ -72,4 +76,10 @@ public class Unit : MonoBehaviour, CanReceiveDamage
 			this.weapon.removeTarget (col.gameObject.GetComponent<CanReceiveDamage> ());
 		}
 	}
+
+	public bool isDead ()
+	{
+		return this == null;
+	} 
+		
 }

--- a/Assets/Scripts/Model/Weapon.cs
+++ b/Assets/Scripts/Model/Weapon.cs
@@ -82,7 +82,7 @@ public class Weapon : MonoBehaviour, CanUpgrade
 			CanReceiveDamage target = this.targets [0];
 
 			// Check if target is already dead
-			if (target.isDead ()) {
+			if (target.getCurrentHealth() <= 0.0f) {
 				Debug.Log (this.gameObject.name + ": TARGET ALREADY DEAD");
 				this.removeTarget (target);
 			} else {

--- a/Assets/Scripts/Model/Weapon.cs
+++ b/Assets/Scripts/Model/Weapon.cs
@@ -63,45 +63,49 @@ public class Weapon : MonoBehaviour, CanUpgrade
 	// Add target to list
 	public void addTarget(CanReceiveDamage target){
 		this.targets.Add (target);
-		Debug.Log ("Targets to attack :" + targets.Count);
+		Debug.Log (this.gameObject.name + "-> Targets to attack :" + targets.Count);
 	}
 
 	// Remove target from list
 	public void removeTarget(CanReceiveDamage target){
 		this.targets.Remove (target);
+		Debug.Log (this.gameObject.name + "-> Targets to attack :" + targets.Count);
+	}
+
+	// Get the available target to attack from the targets list
+	public CanReceiveDamage getAvailableTarget(){
+
+		// Checks if there is a target in the range
+		while (this.targets.Count > 0) {
+
+			// Get target to attack
+			CanReceiveDamage target = this.targets [0];
+
+			// Check if target is already dead
+			if (target.isDead ()) {
+				Debug.Log (this.gameObject.name + ": TARGET ALREADY DEAD");
+				this.removeTarget (target);
+			} else {
+				Debug.Log (this.gameObject.name + ": TARGET AVAILABLE TO SHOOT");
+				return target;
+			}
+		}
+		Debug.Log (this.gameObject.name + ": NO TARGETS ON QUEUE");
+		return null;
 	}
 
 	// Called to attack a target
 	public void Attack()
 	{
-		// Checks if there is a target in the range
-		if (this.targets.Count > 0) {
+		CanReceiveDamage target = getAvailableTarget();
+		if (target != null) {
+			
+			// Set the projectile properties and shoot
+			projectile.Properties (1.0f, target, this.currentDamage);
+			projectile.Shoot ();
 
-			// Get target to attack
-			CanReceiveDamage target = this.targets [0];
-
-			// Check if target was killed by another weapon
-			if(target.isDead ()){
-				Debug.Log ("DEAD BEFORE CREATING PROJECTILE");
-				this.targets.Remove (target);
-			}
-
-			if (this.targets.Count > 0) {
-				// Get target to attack
-				target = this.targets [0];
-
-				// Set the projectile properties
-				projectile.Properties (1.0f, target, this.currentDamage);
-
-				// Shoot the projectile
-				bool dead = projectile.Shoot ();
-				if (dead) {
-					this.targets.Remove (target);
-				}
-
-				// Play sound
-				this.source.PlayOneShot (this.shootSound);
-			}
+			// Play sound
+			this.source.PlayOneShot (this.shootSound);
 		}
 	}
 }

--- a/Assets/Scripts/Model/Weapon.cs
+++ b/Assets/Scripts/Model/Weapon.cs
@@ -78,19 +78,30 @@ public class Weapon : MonoBehaviour, CanUpgrade
 		if (this.targets.Count > 0) {
 
 			// Get target to attack
-			CanReceiveDamage target = targets [0];
+			CanReceiveDamage target = this.targets [0];
 
-			// Set the projectile properties
-			projectile.Properties (1.0f, target, this.currentDamage);
-
-			// Shoot the projectile
-			bool dead = projectile.Shoot ();
-			if (dead) {
+			// Check if target was killed by another weapon
+			if(target.isDead ()){
+				Debug.Log ("DEAD BEFORE CREATING PROJECTILE");
 				this.targets.Remove (target);
 			}
 
-            // Play sound
-			this.source.PlayOneShot (this.shootSound);
+			if (this.targets.Count > 0) {
+				// Get target to attack
+				target = this.targets [0];
+
+				// Set the projectile properties
+				projectile.Properties (1.0f, target, this.currentDamage);
+
+				// Shoot the projectile
+				bool dead = projectile.Shoot ();
+				if (dead) {
+					this.targets.Remove (target);
+				}
+
+				// Play sound
+				this.source.PlayOneShot (this.shootSound);
+			}
 		}
 	}
 }

--- a/Assets/TestScene/LightCameraTest.unity
+++ b/Assets/TestScene/LightCameraTest.unity
@@ -1585,70 +1585,13 @@ Prefab:
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.z
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1000011397538348, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_Name
       value: TowerS
       objectReference: {fileID: 0}
-    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 75
-      objectReference: {fileID: 0}
     - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_LocalPosition.z
       value: -95
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.x
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.y
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 136000013266248522, guid: 68a97d8f079caa14fb7838b4a02d5867,
-        type: 2}
-      propertyPath: m_Radius
-      value: 100
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
@@ -2693,48 +2636,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 41c6984ab5a4baf4aa4b2464eb4732b3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &616228151
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1482904953}
-    m_Modifications:
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0.17
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 18.01
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -0.27
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-  m_IsPrefabParent: 0
 --- !u!1001 &618641250
 Prefab:
   m_ObjectHideFlags: 0
@@ -2962,54 +2863,9 @@ Prefab:
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.z
-      value: 1.0000004
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 1000011397538348, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_Name
       value: TowerE
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.x
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.y
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 75
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 95
-      objectReference: {fileID: 0}
-    - target: {fileID: 136000013266248522, guid: 68a97d8f079caa14fb7838b4a02d5867,
-        type: 2}
-      propertyPath: m_Radius
-      value: 100
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
@@ -4036,30 +3892,49 @@ Prefab:
       propertyPath: m_Name
       value: TowerW
       objectReference: {fileID: 0}
-    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+    - target: {fileID: 0}
       propertyPath: m_LocalScale.x
       value: 3.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+    - target: {fileID: 0}
       propertyPath: m_LocalScale.y
       value: 3.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPosition.x
+      value: -75
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPosition.z
+      value: -95
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_Radius
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000012275614808, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+      propertyPath: m_RootOrder
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_LocalPosition.x
       value: -75
       objectReference: {fileID: 0}
     - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_LocalPosition.z
       value: -95
-      objectReference: {fileID: 0}
-    - target: {fileID: 136000013266248522, guid: 68a97d8f079caa14fb7838b4a02d5867,
-        type: 2}
-      propertyPath: m_Radius
-      value: 100
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
@@ -5050,26 +4925,6 @@ Prefab:
       value: -3.1
       objectReference: {fileID: 0}
     - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1000011397538348, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_Name
-      value: TowerN
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -5086,24 +4941,12 @@ Prefab:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.z
+      propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.x
-      value: 3.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalScale.y
-      value: 3.5
+    - target: {fileID: 1000011397538348, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+      propertyPath: m_Name
+      value: TowerN
       objectReference: {fileID: 0}
     - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_LocalPosition.x
@@ -5112,15 +4955,6 @@ Prefab:
     - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_LocalPosition.z
       value: 95
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 136000013266248522, guid: 68a97d8f079caa14fb7838b4a02d5867,
-        type: 2}
-      propertyPath: m_Radius
-      value: 100
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
@@ -8000,48 +7834,6 @@ Transform:
   m_PrefabParentObject: {fileID: 4000010627994270, guid: f5454958d7b586d4e8a0b15f94e663ff,
     type: 2}
   m_PrefabInternal: {fileID: 1518507566}
---- !u!1001 &1802477721
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 174154301}
-    m_Modifications:
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0.17
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 18.01
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -0.27
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-  m_IsPrefabParent: 0
 --- !u!4 &1817925867 stripped
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 68292a1b590c07144825249b0f4db46b, type: 3}
@@ -8850,48 +8642,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
---- !u!1001 &1976391580
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 205989416}
-    m_Modifications:
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0.17
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 18.01
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -0.27
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-  m_IsPrefabParent: 0
 --- !u!1001 &1989524212
 Prefab:
   m_ObjectHideFlags: 0
@@ -9649,48 +9399,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2107182600}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1001 &2111049090
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 629069869}
-    m_Modifications:
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0.17
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 18.01
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -0.27
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010338026084, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 8272e0817c9093949aec4803487e9574, type: 2}
-  m_IsPrefabParent: 0
 --- !u!1 &2111466489
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Bug to fix: 
- Previous code didn't considered the fact that the same target could be attacked by diferent weapons at the same time, therefore, if a target was killed by one weapon and the others tried to attack an error came up.
 
So now, when a Weapon calls Attack, it runs through the list of targets and gets the first one available to shoot.

Behaviour:
- If the first target in line is already dead (by the weapon itself or by another weapon) it is removed of the target list. This is done successively until there is an available target to shoot or the target list is empty.
- If there is a target to attack, the Projectile is created and shot towards that target.

Other changes: 
- ReceiveDamage doesn't need to return a boolean anymore to notify the target's death.
- Fixed Tower prefab to add the Projectile correctly.
- Fixed FireRange positions on the scene (altered by the fix commented above).

To test it:
- You can set the Base Range of each Tower Weapon to 250 (that provides Fire Ranges big enough so the same Unit collides with at least two towers at the same time, so they have the same target). 