### PR TITLE
Persistent Menu options. Persistent values class created

### DIFF
--- a/Assets/Scenes/MainMenu/OptionMenu.unity
+++ b/Assets/Scenes/MainMenu/OptionMenu.unity
@@ -1365,14 +1365,6 @@ MonoBehaviour:
   isHardButton: 0
   isReturnButton: 1
   audioSource: {fileID: 927727973}
-  volumeSlider: {fileID: 0}
-  musicSlider: {fileID: 0}
-  musicIcon: {fileID: 0}
-  effectsIcon: {fileID: 0}
-  soundFull: {fileID: 0}
-  soundMedium: {fileID: 0}
-  soundLow: {fileID: 0}
-  soundMuted: {fileID: 0}
 --- !u!102 &1119966433
 TextMesh:
   serializedVersion: 3
@@ -1433,6 +1425,7 @@ GameObject:
   m_Component:
   - 4: {fileID: 1282082968}
   - 114: {fileID: 1282082969}
+  - 114: {fileID: 1282082970}
   m_Layer: 0
   m_Name: GameMenu
   m_TagString: Untagged
@@ -1461,7 +1454,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1282082967}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cb8efa7baca364a569eb291e219ae382, type: 3}
   m_Name: 
@@ -1471,6 +1464,17 @@ MonoBehaviour:
   isHardButton: 0
   isReturnButton: 0
   audioSource: {fileID: 376443508}
+--- !u!114 &1282082970
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1282082967}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5ac1cd619befc414ab9339d38c247a97, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
   volumeSlider: {fileID: 1293073786}
   musicSlider: {fileID: 109522167}
   musicIcon: {fileID: 1631480890}
@@ -1687,7 +1691,7 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1282082969}
+        - m_Target: {fileID: 1282082970}
           m_MethodName: musicIconClick
           m_Mode: 1
           m_Arguments:
@@ -2234,7 +2238,7 @@ MonoBehaviour:
     callback:
       m_PersistentCalls:
         m_Calls:
-        - m_Target: {fileID: 1282082969}
+        - m_Target: {fileID: 1282082970}
           m_MethodName: effectsIconClick
           m_Mode: 1
           m_Arguments:

--- a/Assets/Scripts/Menu/SoundOptions.cs
+++ b/Assets/Scripts/Menu/SoundOptions.cs
@@ -1,0 +1,139 @@
+﻿using UnityEngine;
+using System.Collections;
+using UnityEngine.UI;
+
+
+public class SoundOptions : MonoBehaviour {
+
+	//public PersistentVars Vars;
+
+	// Control of volume:
+	public Slider volumeSlider;
+	public Slider musicSlider;
+
+	// Menu icons:
+	public Image musicIcon; 
+	public Image effectsIcon;
+
+	public Sprite soundFull;
+	public Sprite soundMedium;
+	public Sprite soundLow;
+	public Sprite soundMuted;
+
+	private float lastMVolume; // Music volume
+	private float lastEVolume; // Effects volume
+
+    // Use this for initialization
+	void Start () {
+		volumeSlider.onValueChanged.AddListener (delegate {effectsChangeCheck ();});
+		musicSlider.onValueChanged.AddListener (delegate {musicChangeCheck ();});
+		volumeSlider.value = PersistentValues.effectsVolume;
+		musicSlider.value = PersistentValues.musicVolume;
+		lastMVolume = PersistentValues.musicLastVolume;
+		lastEVolume = PersistentValues.effectsLastVolume;
+	}
+	
+	// Update is called once per frame
+	void Update () {
+	}
+	
+	public void effectsChangeCheck(){
+		// We set the AudioListener volume according to the effects slider
+		//AudioListener.volume = volumeSlider.normalizedValue;
+		lastEVolume = volumeSlider.normalizedValue;
+
+		setEffectsIcon();
+		
+		PersistentValues.effectsVolume = volumeSlider.value;
+		PersistentValues.effectsLastVolume = lastEVolume;
+
+	}
+
+
+	// Changes the effects sound
+	private void setEffectsIcon(){
+		// Different icon is shown according to the volume
+		if (volumeSlider.value == 0){
+			effectsIcon.sprite = soundMuted;
+		}
+		else if(volumeSlider.normalizedValue < 0.5f){
+			effectsIcon.sprite = soundLow;
+		}
+		else if(volumeSlider.normalizedValue < 1.0f){
+			effectsIcon.sprite = soundMedium;
+		}
+		else{
+			effectsIcon.sprite = soundFull;
+		}
+	}
+
+	public void musicChangeCheck(){
+
+		AudioListener.volume = musicSlider.normalizedValue;
+		lastMVolume = musicSlider.value;
+		setMusicIcon();
+		
+		PersistentValues.musicVolume = musicSlider.value;
+		PersistentValues.musicLastVolume = lastMVolume;
+	}
+
+
+	// Changes the music sound
+	private void setMusicIcon(){
+		// Different icon is shown according to the volume
+		if (musicSlider.value == 0){
+			musicIcon.sprite = soundMuted;
+		}
+		else if(musicSlider.normalizedValue < 0.5f){
+			musicIcon.sprite = soundLow;
+		}
+		else if(musicSlider.normalizedValue < 1.0f){
+			musicIcon.sprite = soundMedium;
+		}
+		else{
+			musicIcon.sprite = soundFull;
+		}
+	}
+
+
+	public void effectsIconClick(){
+		if (volumeSlider.value == 0){
+			if (lastEVolume == 0){
+				lastEVolume = 1;
+			}
+			//AudioListener.volume = lastEVolume;
+			volumeSlider.value = lastEVolume;
+			setEffectsIcon();
+		}
+		else{
+			float aux = volumeSlider.value;
+			//AudioListener.volume = 0;
+			volumeSlider.value = 0;
+			setEffectsIcon();
+			lastEVolume = aux;
+
+		}
+		
+		PersistentValues.effectsVolume = volumeSlider.value;
+		PersistentValues.effectsLastVolume = lastEVolume;
+	}
+
+	public void musicIconClick(){
+		if (musicSlider.value == 0){
+			if (lastMVolume == 0){
+				lastMVolume = 1;
+			}
+			musicSlider.value = lastMVolume;
+			setMusicIcon();
+		}
+		else{
+			float aux = musicSlider.value;
+			musicSlider.value = 0;
+			setMusicIcon();
+			lastMVolume = aux;
+		}
+		
+		PersistentValues.musicVolume = musicSlider.value;
+		PersistentValues.musicLastVolume = lastMVolume;
+	}
+}

--- a/Assets/Scripts/Menu/SoundOptions.cs.meta
+++ b/Assets/Scripts/Menu/SoundOptions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5ac1cd619befc414ab9339d38c247a97
+timeCreated: 1479571858
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Menu/SubMenu.cs
+++ b/Assets/Scripts/Menu/SubMenu.cs
@@ -12,29 +12,10 @@ public class SubMenu : MonoBehaviour {
 	public bool isReturnButton = false;
     public AudioSource audioSource;
 
-	// Control of volume:
-	public Slider volumeSlider;
-	public Slider musicSlider;
-
-	// Menu icons:
-	public Image musicIcon; 
-	public Image effectsIcon;
-
-	public Sprite soundFull;
-	public Sprite soundMedium;
-	public Sprite soundLow;
-	public Sprite soundMuted;
-
-	private float lastMVolume; // Music volume
-	private float lastEVolume; // Effects volume
 
     // Use this for initialization
     void Start () {
 		
-		volumeSlider.onValueChanged.AddListener (delegate {effectsChangeCheck ();});
-		musicSlider.onValueChanged.AddListener (delegate {musicChangeCheck ();});
-		lastMVolume = 1;
-		lastEVolume = 1;
 	}
 
 	public void OnMouseEnter(){
@@ -70,92 +51,4 @@ public class SubMenu : MonoBehaviour {
         yield return new WaitForSeconds(audioSource.clip.length);
         SceneManager.LoadScene(scene); //Load the game (next scene)  
     }
-
-
-	public void effectsChangeCheck(){
-		// We set the AudioListener volume according to the effects slider
-		//AudioListener.volume = volumeSlider.normalizedValue;
-		lastEVolume = volumeSlider.normalizedValue;
-
-		setEffectsIcon();
-
-	}
-
-
-	// Changes the effects sound
-	private void setEffectsIcon(){
-		// Different icon is shown according to the volume
-		if (volumeSlider.value == 0){
-			effectsIcon.sprite = soundMuted;
-		}
-		else if(volumeSlider.normalizedValue < 0.5f){
-			effectsIcon.sprite = soundLow;
-		}
-		else if(volumeSlider.normalizedValue < 1.0f){
-			effectsIcon.sprite = soundMedium;
-		}
-		else{
-			effectsIcon.sprite = soundFull;
-		}
-	}
-
-	public void musicChangeCheck(){
-
-		lastMVolume = musicSlider.value;
-		setMusicIcon();
-	}
-
-
-	// Changes the music sound
-	private void setMusicIcon(){
-		// Different icon is shown according to the volume
-		if (musicSlider.value == 0){
-			musicIcon.sprite = soundMuted;
-		}
-		else if(musicSlider.normalizedValue < 0.5f){
-			musicIcon.sprite = soundLow;
-		}
-		else if(musicSlider.normalizedValue < 1.0f){
-			musicIcon.sprite = soundMedium;
-		}
-		else{
-			musicIcon.sprite = soundFull;
-		}
-	}
-
-
-	public void effectsIconClick(){
-		if (volumeSlider.value == 0){
-			if (lastEVolume == 0){
-				lastEVolume = 1;
-			}
-			//AudioListener.volume = lastEVolume;
-			volumeSlider.value = lastEVolume;
-			setEffectsIcon();
-		}
-		else{
-			float aux = volumeSlider.value;
-			//AudioListener.volume = 0;
-			volumeSlider.value = 0;
-			setEffectsIcon();
-			lastEVolume = aux;
-
-		}
-	}
-
-	public void musicIconClick(){
-		if (musicSlider.value == 0){
-			if (lastMVolume == 0){
-				lastMVolume = 1;
-			}
-			musicSlider.value = lastMVolume;
-			setMusicIcon();
-		}
-		else{
-			float aux = musicSlider.value;
-			musicSlider.value = 0;
-			setMusicIcon();
-			lastMVolume = aux;
-		}
-	}
 }

--- a/Assets/Scripts/PersistentValues.cs
+++ b/Assets/Scripts/PersistentValues.cs
@@ -1,0 +1,15 @@
+﻿using UnityEngine;
+using System.Collections;
+
+public class PersistentValues : MonoBehaviour {
+
+	public static float musicVolume = 1;
+	public static float musicLastVolume = 1;
+	public static float effectsVolume = 1;
+	public static float effectsLastVolume = 1;
+
+	void Awake(){
+		DontDestroyOnLoad(this);
+	}
+
+}

--- a/Assets/Scripts/PersistentValues.cs.meta
+++ b/Assets/Scripts/PersistentValues.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9c3c31beccc424e478a27435123fd981
+timeCreated: 1479572342
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -40,8 +40,10 @@ public class UIManager : MonoBehaviour {
 		volumeSlider.onValueChanged.AddListener (delegate {effectsChangeCheck ();});
 		musicSlider.onValueChanged.AddListener (delegate {musicChangeCheck ();});
 		
-		lastMVolume = 1;
-		lastEVolume = 1;
+		volumeSlider.value = PersistentValues.effectsVolume;
+		musicSlider.value = PersistentValues.musicVolume;
+		lastMVolume = PersistentValues.musicLastVolume;
+		lastEVolume = PersistentValues.effectsLastVolume;
 	}
 
 	// Update is called once per frame
@@ -82,6 +84,8 @@ public class UIManager : MonoBehaviour {
 			lastEVolume = aux;
 			
 		}
+		PersistentValues.effectsVolume = volumeSlider.value;
+		PersistentValues.effectsLastVolume = lastEVolume;
 	}
 	
 	// This function is called when we change the effects slider value
@@ -90,6 +94,8 @@ public class UIManager : MonoBehaviour {
 		AudioListener.volume = volumeSlider.normalizedValue;
 		lastEVolume = AudioListener.volume;
 		
+		PersistentValues.effectsVolume = volumeSlider.value;
+		PersistentValues.effectsLastVolume = lastEVolume;
 		setEffectsIcon();
 		
 	}
@@ -126,6 +132,8 @@ public class UIManager : MonoBehaviour {
 			setMusicIcon();
 			lastMVolume = aux;
 		}
+		PersistentValues.musicVolume = musicSlider.value;
+		PersistentValues.musicLastVolume = lastMVolume;
 	}
 	
 	// This function is called everytime we change the music slider value
@@ -133,6 +141,9 @@ public class UIManager : MonoBehaviour {
 		
 		lastMVolume = musicSlider.value;
 		setMusicIcon();
+		
+		PersistentValues.musicVolume = musicSlider.value;
+		PersistentValues.musicLastVolume = lastMVolume;
 	}
 	
 	// This function sets the correct icon volume


### PR DESCRIPTION
No hay imagen pues los cambios no son visuales.

Al variar el volumen en el menú principal, los cambios se reflejan también en la escena de juego.
Para ello se ha modificado ligeramente en funcionamiento de los scripts del menú (dividiendo responsabilidades), y se ha creado una clase persistente llamada PersistentValues.cs.
En esta clase podemos guardar valores que queramos conservar entre escenas, y puede ser invocada y editada desde cualquier escena.

También se ha arreglado un error por referéncia equívoca que había en submenu.cs.

Probarlo es tan simple como ejecutar el menú, ir a opciones, cambiar valores, i comprobar que persisten entre escenas.

ISSUE: https://github.com/NestorTejero/ES2016B/issues/234