### PR TITLE
Fix/make tower range centered

### DIFF
--- a/Assets/Prefabs/EdificiUB.prefab
+++ b/Assets/Prefabs/EdificiUB.prefab
@@ -89,7 +89,7 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 0}
+  - {fileID: 2100000, guid: 1e10c3c7ca8638e4ea5e50844d254ba4, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
@@ -122,8 +122,8 @@ BoxCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 14.050818, y: 3.4227073, z: 6.1198244}
-  m_Center: {x: 0.051974587, y: -0.60742253, z: 1.8777386}
+  m_Size: {x: 14.050818, y: 3.4227073, z: 0.1}
+  m_Center: {x: 0.051974587, y: -0.60742253, z: 0}
 --- !u!95 &95000012103147354
 Animator:
   serializedVersion: 3
@@ -177,10 +177,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   baseHealth: 200
-  upgradeFactor: 1.1
-  upgradeCost: 10
-  repairQuantity: 10
   repairCost: 10
+  repairQuantity: 10
+  upgradeCost: 10
+  upgradeFactor: 1.1
 --- !u!114 &114000013401498404
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/GridRelated/Grid+Camera.prefab
+++ b/Assets/Prefabs/GridRelated/Grid+Camera.prefab
@@ -196,15 +196,15 @@ MonoBehaviour:
   buildingsMask:
     serializedVersion: 2
     m_Bits: 256
-  cellSize: 1
-  gridWidth: 50
-  gridHeight: 50
-  yOffset: 0.5
-  cellMaterialValid: {fileID: 2100000, guid: 07785684b5cbbb644be72d8269c262be, type: 2}
   cellMaterialInvalid: {fileID: 2100000, guid: af37296f72ff43c4cb450aec8d54df72, type: 2}
+  cellMaterialValid: {fileID: 2100000, guid: 07785684b5cbbb644be72d8269c262be, type: 2}
+  cellSize: 1
+  gridHeight: 50
+  gridWidth: 50
   tower: {fileID: 1000011397538348, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
   towerShadow: {fileID: 1000011985423730, guid: 8771457fed3922447b029435a307b147,
     type: 2}
+  yOffset: 0.5
 --- !u!114 &114000012404773614
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -219,25 +219,25 @@ MonoBehaviour:
   groundLayer:
     serializedVersion: 2
     m_Bits: 1
+  input:
+    ORBIT_Y: MouseTurn
+    PAN: MousePan
+    ZOOM: Mouse ScrollWheel
+  orbit:
+    allowOrbit: 1
+    xRotation: 50
+    yOrbitSmooth: 5
+    yRotation: 0
   position:
-    invertPan: 1
-    panSmooth: 7
-    distanceFromGround: 60
     allowZoom: 1
-    zoomSmoth: 5
-    zoomStep: 5
+    distanceFromGround: 60
+    invertPan: 1
     maxZoom: 40
     minZoom: 80
     newDistance: 60
-  orbit:
-    xRotation: 50
-    yRotation: 0
-    allowOrbit: 1
-    yOrbitSmooth: 5
-  input:
-    PAN: MousePan
-    ORBIT_Y: MouseTurn
-    ZOOM: Mouse ScrollWheel
+    panSmooth: 7
+    zoomSmoth: 5
+    zoomStep: 5
 --- !u!114 &114000013528213974
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -249,11 +249,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 19131f013372765439b9aa9391d3ba10, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  EasyAI: {fileID: 1000013852025098, guid: a3a6ddb75a3205841ba1472cdca08e5c, type: 2}
   gameController: {fileID: 1000011688498418, guid: c5cd0f004f98f714995e5d843d78918a,
     type: 2}
-  MediumAI: {fileID: 0}
-  EasyAI: {fileID: 0}
-  HardAI: {fileID: 0}
+  HardAI: {fileID: 1000014065262796, guid: 1f705680d27dc844aa565d8a5bdea8cb, type: 2}
+  MediumAI: {fileID: 1000012482274262, guid: 2ec18a7bc2ea112499b471d4e0b3513c, type: 2}
 --- !u!114 &114000013589342588
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Players/EasyAI.prefab
+++ b/Assets/Prefabs/Players/EasyAI.prefab
@@ -51,4 +51,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dbf3a1ab1c02eeb4e97d43c112c52607, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  initialCoins: 50
+  initialCoins: 10

--- a/Assets/Prefabs/Players/EasyAI.prefab
+++ b/Assets/Prefabs/Players/EasyAI.prefab
@@ -51,4 +51,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dbf3a1ab1c02eeb4e97d43c112c52607, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  initialCoins: 10
+  initialCoins: 50

--- a/Assets/Prefabs/Players/HardAI.prefab
+++ b/Assets/Prefabs/Players/HardAI.prefab
@@ -51,4 +51,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fd4e647ec7a53fe41b22727a201074e3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  initialCoins: 1000
+  initialCoins: 10

--- a/Assets/Prefabs/Sun_Moon_Stars.prefab
+++ b/Assets/Prefabs/Sun_Moon_Stars.prefab
@@ -96,7 +96,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000010960794684}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 148.21144, y: 0.2657254, z: 0.0000019073486}
+  m_LocalPosition: {x: 112.10071, y: -11.477163, z: -5.471145}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
@@ -211,13 +211,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dayLength: 0.5
-  nightLength: 0.2
-  time: 1
   hour: 0
-  ubCenter: {fileID: 0}
-  sun: {fileID: 108000011949886082}
   moon: {fileID: 108000010415340492}
+  nightLength: 0.2
   stars: {fileID: 198000013440651658}
+  sun: {fileID: 108000011949886082}
+  time: 1
+  ubCenter: {fileID: 0}
 --- !u!198 &198000013440651658
 ParticleSystem:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Towers/Tower.prefab
+++ b/Assets/Prefabs/Towers/Tower.prefab
@@ -22,6 +22,7 @@ GameObject:
   - 33: {fileID: 33000013261260516}
   - 23: {fileID: 23000012569671148}
   - 95: {fileID: 95000012390861510}
+  - 64: {fileID: 64000014029813626}
   m_Layer: 8
   m_Name: TowerModel
   m_TagString: Untagged
@@ -72,7 +73,7 @@ GameObject:
   m_Component:
   - 4: {fileID: 4000011863964682}
   - 136: {fileID: 136000013266248522}
-  m_Layer: 0
+  m_Layer: 2
   m_Name: FireRange
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -101,10 +102,10 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000012882011190}
-  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 10, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000011410470234}
   m_RootOrder: 1
@@ -186,6 +187,18 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!64 &64000014029813626
+MeshCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010893995726}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300000, guid: 791bdb27c1bbc6b46b97929351d80d32, type: 3}
 --- !u!95 &95000012390861510
 Animator:
   serializedVersion: 3
@@ -216,7 +229,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   baseCooldown: 1
   baseDamage: 10
-  baseRange: 15
+  baseRange: 50
   proj_obj: {fileID: 1000012011802270, guid: dd4ce48133aa3a64db2f85c879d52083, type: 2}
   proj_origin: {fileID: 1000011089548668}
   shootSound: {fileID: 8300000, guid: 2a055584652ad8c4ab2ad9c3b19a043f, type: 3}
@@ -254,7 +267,7 @@ CapsuleCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
-  m_Radius: 100
+  m_Radius: 50
   m_Height: 30
   m_Direction: 2
-  m_Center: {x: 1, y: 0, z: 7}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/UnitShop.prefab
+++ b/Assets/Prefabs/UnitShop.prefab
@@ -57,4 +57,9 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   units:
-  - {fileID: 1000013888679622, guid: b59ff40f280f3434ea61c01fbebaf21e, type: 2}
+  - {fileID: 1000011473136326, guid: b8ab8573765f82244ac14c0a59b5a573, type: 2}
+  - {fileID: 1000011565917486, guid: 486d8061b7a6f6540af997e9ea974e3f, type: 2}
+  - {fileID: 1000013263705146, guid: 4de060bdaa5ff1d4b899dcd9cf4757b0, type: 2}
+  - {fileID: 1000011473136326, guid: b8ab8573765f82244ac14c0a59b5a573, type: 2}
+  - {fileID: 1000010714520526, guid: 650147df6ca7cc248950ef57918bb9c3, type: 2}
+  - {fileID: 1000011433983142, guid: c769837888a7de342b1e7569b205ef6d, type: 2}

--- a/Assets/Prefabs/selectedObjectIndicator.prefab
+++ b/Assets/Prefabs/selectedObjectIndicator.prefab
@@ -37,7 +37,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000014165887990}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -195.31921, y: -0.19999981, z: -91.67984}
+  m_LocalPosition: {x: 16.510864, y: -0.19999981, z: 270.9625}
   m_LocalScale: {x: 3, y: 3, z: 3}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []

--- a/Assets/TestScene/LightCameraTest.unity
+++ b/Assets/TestScene/LightCameraTest.unity
@@ -5857,39 +5857,7 @@ Prefab:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 4000013924541314, guid: 778a586d1752e4349887fb6a4a1f6d1a, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 16.510864
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013924541314, guid: 778a586d1752e4349887fb6a4a1f6d1a, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -0.19999981
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013924541314, guid: 778a586d1752e4349887fb6a4a1f6d1a, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 270.9625
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013924541314, guid: 778a586d1752e4349887fb6a4a1f6d1a, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013924541314, guid: 778a586d1752e4349887fb6a4a1f6d1a, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013924541314, guid: 778a586d1752e4349887fb6a4a1f6d1a, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013924541314, guid: 778a586d1752e4349887fb6a4a1f6d1a, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013924541314, guid: 778a586d1752e4349887fb6a4a1f6d1a, type: 2}
       propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1000014165887990, guid: 778a586d1752e4349887fb6a4a1f6d1a, type: 2}
-      propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -6996,55 +6964,9 @@ Prefab:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 4000013824751034, guid: dc0d54ea4544dfd419444fd2c520eb25, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 40
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013824751034, guid: dc0d54ea4544dfd419444fd2c520eb25, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013824751034, guid: dc0d54ea4544dfd419444fd2c520eb25, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013824751034, guid: dc0d54ea4544dfd419444fd2c520eb25, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013824751034, guid: dc0d54ea4544dfd419444fd2c520eb25, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013824751034, guid: dc0d54ea4544dfd419444fd2c520eb25, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013824751034, guid: dc0d54ea4544dfd419444fd2c520eb25, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013824751034, guid: dc0d54ea4544dfd419444fd2c520eb25, type: 2}
       propertyPath: m_RootOrder
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 114000013528213974, guid: dc0d54ea4544dfd419444fd2c520eb25,
-        type: 2}
-      propertyPath: MediumAI
-      value: 
-      objectReference: {fileID: 1000012482274262, guid: 2ec18a7bc2ea112499b471d4e0b3513c,
-        type: 2}
-    - target: {fileID: 114000013528213974, guid: dc0d54ea4544dfd419444fd2c520eb25,
-        type: 2}
-      propertyPath: EasyAI
-      value: 
-      objectReference: {fileID: 1000013852025098, guid: a3a6ddb75a3205841ba1472cdca08e5c,
-        type: 2}
-    - target: {fileID: 114000013528213974, guid: dc0d54ea4544dfd419444fd2c520eb25,
-        type: 2}
-      propertyPath: HardAI
-      value: 
-      objectReference: {fileID: 1000014065262796, guid: 1f705680d27dc844aa565d8a5bdea8cb,
-        type: 2}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: dc0d54ea4544dfd419444fd2c520eb25, type: 2}
   m_IsPrefabParent: 0
@@ -15091,34 +15013,6 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 1493911324}
     m_Modifications:
-    - target: {fileID: 4000010627994270, guid: f5454958d7b586d4e8a0b15f94e663ff, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 112.10071
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010627994270, guid: f5454958d7b586d4e8a0b15f94e663ff, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -11.477163
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010627994270, guid: f5454958d7b586d4e8a0b15f94e663ff, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -5.471145
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010627994270, guid: f5454958d7b586d4e8a0b15f94e663ff, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010627994270, guid: f5454958d7b586d4e8a0b15f94e663ff, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010627994270, guid: f5454958d7b586d4e8a0b15f94e663ff, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000010627994270, guid: f5454958d7b586d4e8a0b15f94e663ff, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 4000010627994270, guid: f5454958d7b586d4e8a0b15f94e663ff, type: 2}
       propertyPath: m_RootOrder
       value: 2

--- a/Assets/TestScene/LightCameraTest.unity
+++ b/Assets/TestScene/LightCameraTest.unity
@@ -3754,18 +3754,6 @@ Prefab:
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 18.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -0.3
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
   m_IsPrefabParent: 0
@@ -4788,23 +4776,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 296891813}
   m_RootOrder: 1
---- !u!1 &476701382 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1000010893995726, guid: 68a97d8f079caa14fb7838b4a02d5867,
-    type: 2}
-  m_PrefabInternal: {fileID: 392682460}
---- !u!64 &476701387
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 476701382}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Convex: 1
-  m_Mesh: {fileID: 4300000, guid: 791bdb27c1bbc6b46b97929351d80d32, type: 3}
 --- !u!1001 &488724154
 Prefab:
   m_ObjectHideFlags: 0
@@ -6645,18 +6616,6 @@ Prefab:
     - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 18.8
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -0.3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}

--- a/Assets/TestScene/LightCameraTest.unity
+++ b/Assets/TestScene/LightCameraTest.unity
@@ -2767,34 +2767,6 @@ Prefab:
     m_TransformParent: {fileID: 296891813}
     m_Modifications:
     - target: {fileID: 4000011911116396, guid: c5cd0f004f98f714995e5d843d78918a, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -282.31314
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011911116396, guid: c5cd0f004f98f714995e5d843d78918a, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 58.0625
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011911116396, guid: c5cd0f004f98f714995e5d843d78918a, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 225.02008
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011911116396, guid: c5cd0f004f98f714995e5d843d78918a, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011911116396, guid: c5cd0f004f98f714995e5d843d78918a, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011911116396, guid: c5cd0f004f98f714995e5d843d78918a, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011911116396, guid: c5cd0f004f98f714995e5d843d78918a, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011911116396, guid: c5cd0f004f98f714995e5d843d78918a, type: 2}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
@@ -3757,22 +3729,6 @@ Prefab:
       value: -33.5
       objectReference: {fileID: 0}
     - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
@@ -3790,17 +3746,25 @@ Prefab:
       propertyPath: m_Name
       value: TowerS
       objectReference: {fileID: 0}
-    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -95
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 75
-      objectReference: {fileID: 0}
     - target: {fileID: 1000010893995726, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_TagString
       value: Tower
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 18.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -0.3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
@@ -4824,6 +4788,23 @@ Transform:
   m_Children: []
   m_Father: {fileID: 296891813}
   m_RootOrder: 1
+--- !u!1 &476701382 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1000010893995726, guid: 68a97d8f079caa14fb7838b4a02d5867,
+    type: 2}
+  m_PrefabInternal: {fileID: 392682460}
+--- !u!64 &476701387
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 476701382}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Convex: 1
+  m_Mesh: {fileID: 4300000, guid: 791bdb27c1bbc6b46b97929351d80d32, type: 3}
 --- !u!1001 &488724154
 Prefab:
   m_ObjectHideFlags: 0
@@ -6644,22 +6625,6 @@ Prefab:
       value: -3.1
       objectReference: {fileID: 0}
     - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
@@ -6678,12 +6643,20 @@ Prefab:
       value: TowerE
       objectReference: {fileID: 0}
     - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 95
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_LocalPosition.x
-      value: 75
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 18.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000013693324336, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -0.3
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
@@ -9567,22 +9540,6 @@ Prefab:
       value: -33.5
       objectReference: {fileID: 0}
     - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
@@ -9600,13 +9557,13 @@ Prefab:
       propertyPath: m_Name
       value: TowerW
       objectReference: {fileID: 0}
-    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: -95
+    - target: {fileID: 4000013186379108, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -75
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
@@ -10982,7 +10939,7 @@ Transform:
   - {fileID: 1448158032}
   - {fileID: 1936545542}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
 --- !u!4 &1053215976 stripped
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 5e7e4a46119ad774b91921b4751121ce, type: 3}
@@ -11789,22 +11746,6 @@ Prefab:
       value: -3.1
       objectReference: {fileID: 0}
     - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011410470234, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
@@ -11823,12 +11764,8 @@ Prefab:
       value: TowerN
       objectReference: {fileID: 0}
     - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 95
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000011863964682, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -75
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 68a97d8f079caa14fb7838b4a02d5867, type: 2}
@@ -13783,57 +13720,9 @@ Prefab:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 4000012602783024, guid: c839f3d5ec503fe429715f930afaf77d, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 71.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000012602783024, guid: c839f3d5ec503fe429715f930afaf77d, type: 2}
-      propertyPath: m_LocalPosition.y
+      propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 4000012602783024, guid: c839f3d5ec503fe429715f930afaf77d, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 40.9
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000012602783024, guid: c839f3d5ec503fe429715f930afaf77d, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000012602783024, guid: c839f3d5ec503fe429715f930afaf77d, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000012602783024, guid: c839f3d5ec503fe429715f930afaf77d, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000012602783024, guid: c839f3d5ec503fe429715f930afaf77d, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000012602783024, guid: c839f3d5ec503fe429715f930afaf77d, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 23000010479735522, guid: c839f3d5ec503fe429715f930afaf77d,
-        type: 2}
-      propertyPath: m_Materials.Array.data[0]
-      value: 
-      objectReference: {fileID: 2100000, guid: 1e10c3c7ca8638e4ea5e50844d254ba4, type: 2}
-    - target: {fileID: 23000010479735522, guid: c839f3d5ec503fe429715f930afaf77d,
-        type: 2}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 95000012103147354, guid: c839f3d5ec503fe429715f930afaf77d,
-        type: 2}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 33000010262893958, guid: c839f3d5ec503fe429715f930afaf77d,
-        type: 2}
-      propertyPath: m_Mesh
-      value: 
-      objectReference: {fileID: 4300000, guid: 9f679d75d350f7e47accab1424c3379c, type: 3}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: c839f3d5ec503fe429715f930afaf77d, type: 2}
   m_IsPrefabParent: 0
@@ -20409,39 +20298,6 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 296891813}
     m_Modifications:
-    - target: {fileID: 114000010288231944, guid: 4537ec399d51e244290ba3589cdd2a58,
-        type: 2}
-      propertyPath: units.Array.size
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013832137182, guid: 4537ec399d51e244290ba3589cdd2a58, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -284.5907
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013832137182, guid: 4537ec399d51e244290ba3589cdd2a58, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 62.901962
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013832137182, guid: 4537ec399d51e244290ba3589cdd2a58, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 203.82153
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013832137182, guid: 4537ec399d51e244290ba3589cdd2a58, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013832137182, guid: 4537ec399d51e244290ba3589cdd2a58, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013832137182, guid: 4537ec399d51e244290ba3589cdd2a58, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4000013832137182, guid: 4537ec399d51e244290ba3589cdd2a58, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 4000013832137182, guid: 4537ec399d51e244290ba3589cdd2a58, type: 2}
       propertyPath: m_RootOrder
       value: 2
@@ -20466,42 +20322,6 @@ Prefab:
       propertyPath: respawns.Array.data[3]
       value: 
       objectReference: {fileID: 878300465}
-    - target: {fileID: 114000010288231944, guid: 4537ec399d51e244290ba3589cdd2a58,
-        type: 2}
-      propertyPath: units.Array.data[0]
-      value: 
-      objectReference: {fileID: 1000011473136326, guid: b8ab8573765f82244ac14c0a59b5a573,
-        type: 2}
-    - target: {fileID: 114000010288231944, guid: 4537ec399d51e244290ba3589cdd2a58,
-        type: 2}
-      propertyPath: units.Array.data[1]
-      value: 
-      objectReference: {fileID: 1000011565917486, guid: 486d8061b7a6f6540af997e9ea974e3f,
-        type: 2}
-    - target: {fileID: 114000010288231944, guid: 4537ec399d51e244290ba3589cdd2a58,
-        type: 2}
-      propertyPath: units.Array.data[2]
-      value: 
-      objectReference: {fileID: 1000013263705146, guid: 4de060bdaa5ff1d4b899dcd9cf4757b0,
-        type: 2}
-    - target: {fileID: 114000010288231944, guid: 4537ec399d51e244290ba3589cdd2a58,
-        type: 2}
-      propertyPath: units.Array.data[3]
-      value: 
-      objectReference: {fileID: 1000011473136326, guid: b8ab8573765f82244ac14c0a59b5a573,
-        type: 2}
-    - target: {fileID: 114000010288231944, guid: 4537ec399d51e244290ba3589cdd2a58,
-        type: 2}
-      propertyPath: units.Array.data[4]
-      value: 
-      objectReference: {fileID: 1000010714520526, guid: 650147df6ca7cc248950ef57918bb9c3,
-        type: 2}
-    - target: {fileID: 114000010288231944, guid: 4537ec399d51e244290ba3589cdd2a58,
-        type: 2}
-      propertyPath: units.Array.data[5]
-      value: 
-      objectReference: {fileID: 1000011433983142, guid: c769837888a7de342b1e7569b205ef6d,
-        type: 2}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 4537ec399d51e244290ba3589cdd2a58, type: 2}
   m_IsPrefabParent: 0


### PR DESCRIPTION
- Made all tower's shooting range centered in tower's center

- Made all possible scene objects inherit from their prefab (so that you don't have to touch the scene to change values)

- Made HardAI have 10 of Money as all the others (now I understand why it spammed so many Units)

- Fixed UB + Towers clicking for HUD:

1. Created a MeshCollider for TowerModel (to click on tower)

2. Added Tower's Capsule Collider to IgnoreRayCasts layer (to not to use to click)

3. Resized UB's Boxcollider to have size_z=0.1 (a thin layer of BoxCollider for Units) to avoid clicking UB even if not wanted to