### PR TITLE
Minimap

### DIFF
--- a/Assets/Materials/Minimap.meta
+++ b/Assets/Materials/Minimap.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9000977541068194b8565999b267a0ef
+folderAsset: yes
+timeCreated: 1481061229
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/Minimap/BlueSphere.mat
+++ b/Assets/Materials/Minimap/BlueSphere.mat
@@ -1,0 +1,127 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: BlueSphere
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _EMISSION _GLOSSYREFLECTIONS_OFF _SPECULARHIGHLIGHTS_OFF
+  m_LightmapFlags: 1
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  m_SavedProperties:
+    serializedVersion: 2
+    m_TexEnvs:
+    - first:
+        name: _BumpMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _DetailAlbedoMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _DetailMask
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _DetailNormalMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _EmissionMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _MainTex
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _MetallicGlossMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _OcclusionMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _ParallaxMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - first:
+        name: _BumpScale
+      second: 1
+    - first:
+        name: _Cutoff
+      second: 0.5
+    - first:
+        name: _DetailNormalMapScale
+      second: 1
+    - first:
+        name: _DstBlend
+      second: 0
+    - first:
+        name: _GlossMapScale
+      second: 1
+    - first:
+        name: _Glossiness
+      second: 1
+    - first:
+        name: _GlossyReflections
+      second: 0
+    - first:
+        name: _Metallic
+      second: 1
+    - first:
+        name: _Mode
+      second: 0
+    - first:
+        name: _OcclusionStrength
+      second: 1
+    - first:
+        name: _Parallax
+      second: 0.02
+    - first:
+        name: _SmoothnessTextureChannel
+      second: 0
+    - first:
+        name: _SpecularHighlights
+      second: 0
+    - first:
+        name: _SrcBlend
+      second: 1
+    - first:
+        name: _UVSec
+      second: 0
+    - first:
+        name: _ZWrite
+      second: 1
+    m_Colors:
+    - first:
+        name: _Color
+      second: {r: 1, g: 1, b: 1, a: 1}
+    - first:
+        name: _EmissionColor
+      second: {r: 0.19999981, g: 0, b: 1, a: 1}

--- a/Assets/Materials/Minimap/BlueSphere.mat.meta
+++ b/Assets/Materials/Minimap/BlueSphere.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f3ab6de4d6c3dd14c954bd34b282ed7e
+timeCreated: 1481061238
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/Minimap/RedSphere.mat
+++ b/Assets/Materials/Minimap/RedSphere.mat
@@ -1,0 +1,127 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: RedSphere
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _EMISSION _GLOSSYREFLECTIONS_OFF _SPECULARHIGHLIGHTS_OFF
+  m_LightmapFlags: 1
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  m_SavedProperties:
+    serializedVersion: 2
+    m_TexEnvs:
+    - first:
+        name: _BumpMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _DetailAlbedoMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _DetailMask
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _DetailNormalMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _EmissionMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _MainTex
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _MetallicGlossMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _OcclusionMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - first:
+        name: _ParallaxMap
+      second:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - first:
+        name: _BumpScale
+      second: 1
+    - first:
+        name: _Cutoff
+      second: 0.5
+    - first:
+        name: _DetailNormalMapScale
+      second: 1
+    - first:
+        name: _DstBlend
+      second: 0
+    - first:
+        name: _GlossMapScale
+      second: 1
+    - first:
+        name: _Glossiness
+      second: 1
+    - first:
+        name: _GlossyReflections
+      second: 0
+    - first:
+        name: _Metallic
+      second: 1
+    - first:
+        name: _Mode
+      second: 0
+    - first:
+        name: _OcclusionStrength
+      second: 1
+    - first:
+        name: _Parallax
+      second: 0.02
+    - first:
+        name: _SmoothnessTextureChannel
+      second: 0
+    - first:
+        name: _SpecularHighlights
+      second: 0
+    - first:
+        name: _SrcBlend
+      second: 1
+    - first:
+        name: _UVSec
+      second: 0
+    - first:
+        name: _ZWrite
+      second: 1
+    m_Colors:
+    - first:
+        name: _Color
+      second: {r: 1, g: 1, b: 1, a: 1}
+    - first:
+        name: _EmissionColor
+      second: {r: 1, g: 0, b: 0, a: 1}

--- a/Assets/Materials/Minimap/RedSphere.mat.meta
+++ b/Assets/Materials/Minimap/RedSphere.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 037616029cc63044d888d6e67bad3137
+timeCreated: 1481061238
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/GameMenu.prefab
+++ b/Assets/Prefabs/GameMenu.prefab
@@ -1423,9 +1423,9 @@ MonoBehaviour:
   m_HandleRect: {fileID: 224000013368166984}
   m_Direction: 0
   m_MinValue: 0
-  m_MaxValue: 1
+  m_MaxValue: 0.5
   m_WholeNumbers: 0
-  m_Value: 1
+  m_Value: 0.5
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
@@ -2452,7 +2452,7 @@ RectTransform:
   m_RootOrder: 0
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -9, y: -240}
+  m_AnchoredPosition: {x: -484, y: -440}
   m_SizeDelta: {x: 640, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &224000012825227868

--- a/Assets/Prefabs/GridRelated/Grid+Camera.prefab
+++ b/Assets/Prefabs/GridRelated/Grid+Camera.prefab
@@ -51,6 +51,24 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000012453651090
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000014272620920}
+  - 33: {fileID: 33000010279276432}
+  - 135: {fileID: 135000013893792656}
+  - 23: {fileID: 23000013125870004}
+  m_Layer: 11
+  m_Name: MainSphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1000013286130206
 GameObject:
   m_ObjectHideFlags: 0
@@ -76,7 +94,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 70, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 45, y: 45, z: 0}
-  m_Children: []
+  m_Children:
+  - {fileID: 4000014272620920}
   m_Father: {fileID: 4000013824751034}
   m_RootOrder: 0
 --- !u!4 &4000013261528032
@@ -107,6 +126,19 @@ Transform:
   - {fileID: 4000013261528032}
   m_Father: {fileID: 0}
   m_RootOrder: 0
+--- !u!4 &4000014272620920
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012453651090}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 15, y: 15, z: 15}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 4000012445027732}
+  m_RootOrder: 0
 --- !u!20 &20000014000386090
 Camera:
   m_ObjectHideFlags: 1
@@ -131,7 +163,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 4294965247
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -141,6 +173,42 @@ Camera:
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
   m_StereoMirrorMode: 0
+--- !u!23 &23000013125870004
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012453651090}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: f3ab6de4d6c3dd14c954bd34b282ed7e, type: 2}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!33 &33000010279276432
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012453651090}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!54 &54000013282089672
 Rigidbody:
   m_ObjectHideFlags: 1
@@ -274,3 +342,15 @@ Behaviour:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000010658379778}
   m_Enabled: 1
+--- !u!135 &135000013893792656
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012453651090}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 1
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Minimap.meta
+++ b/Assets/Prefabs/Minimap.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f9bd53663e24a7a4783cc807b0bf4d49
+folderAsset: yes
+timeCreated: 1481063489
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Minimap/Minimap.prefab
+++ b/Assets/Prefabs/Minimap/Minimap.prefab
@@ -1,0 +1,113 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1000010579224922}
+  m_IsPrefabParent: 1
+--- !u!1 &1000010579224922
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000014048068682}
+  - 20: {fileID: 20000012099796476}
+  - 124: {fileID: 124000011548431216}
+  - 92: {fileID: 92000013400258594}
+  - 81: {fileID: 81000011339500834}
+  - 114: {fileID: 114000010097744786}
+  m_Layer: 0
+  m_Name: Minimap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4000014048068682
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010579224922}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 100, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!20 &20000012099796476
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010579224922}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0.75
+    y: 0.75
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 101
+  field of view: 60
+  orthographic: 1
+  orthographic size: 100
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
+--- !u!81 &81000011339500834
+AudioListener:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010579224922}
+  m_Enabled: 0
+--- !u!92 &92000013400258594
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010579224922}
+  m_Enabled: 1
+--- !u!114 &114000010097744786
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010579224922}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce89bbe4477e11340b81a97eebadb692, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Tarjet: {fileID: 0}
+--- !u!124 &124000011548431216
+Behaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010579224922}
+  m_Enabled: 1

--- a/Assets/Prefabs/Minimap/Minimap.prefab.meta
+++ b/Assets/Prefabs/Minimap/Minimap.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10bcc405a3b05d741a42b45585c08586
+timeCreated: 1481063492
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Units/UnitAngryStudent.prefab
+++ b/Assets/Prefabs/Units/UnitAngryStudent.prefab
@@ -476,6 +476,24 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000012350886342
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000012420997620}
+  - 33: {fileID: 33000013751414428}
+  - 135: {fileID: 135000011419551374}
+  - 23: {fileID: 23000011661615068}
+  m_Layer: 11
+  m_Name: EnemySphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1000012552417218
 GameObject:
   m_ObjectHideFlags: 1
@@ -1240,6 +1258,19 @@ Transform:
   - {fileID: 4000013357474454}
   m_Father: {fileID: 4000011075249470}
   m_RootOrder: 0
+--- !u!4 &4000012420997620
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012350886342}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -66.67212, y: -0.049999952, z: -53.239468}
+  m_LocalScale: {x: 2.9999998, y: 2.9999998, z: 2.9999998}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 4000013459174682}
+  m_RootOrder: 2
 --- !u!4 &4000012617922280
 Transform:
   m_ObjectHideFlags: 1
@@ -1475,6 +1506,7 @@ Transform:
   m_Children:
   - {fileID: 4000010526193654}
   - {fileID: 4000012951435394}
+  - {fileID: 4000012420997620}
   m_Father: {fileID: 4000013050671088}
   m_RootOrder: 0
 --- !u!4 &4000013510819104
@@ -1673,6 +1705,42 @@ Transform:
   - {fileID: 4000010453616266}
   m_Father: {fileID: 4000013904547654}
   m_RootOrder: 0
+--- !u!23 &23000011661615068
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012350886342}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 037616029cc63044d888d6e67bad3137, type: 2}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!33 &33000013751414428
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012350886342}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!54 &54000012034588780
 Rigidbody:
   m_ObjectHideFlags: 1
@@ -1767,6 +1835,18 @@ MonoBehaviour:
   - {fileID: 1000010710961544, guid: 2e8b93f0bfb9bde4eb2da65533f3af7d, type: 2}
   proj_origin: {fileID: 1000013916661712}
   shootSound: {fileID: 8300000, guid: cf73db8e4891a754791d586816040dff, type: 3}
+--- !u!135 &135000011419551374
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012350886342}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!136 &136000012203421290
 CapsuleCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Units/UnitExchangeStudent.prefab
+++ b/Assets/Prefabs/Units/UnitExchangeStudent.prefab
@@ -86,6 +86,24 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000010428899144
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000014114737130}
+  - 33: {fileID: 33000014066670310}
+  - 135: {fileID: 135000012402957608}
+  - 23: {fileID: 23000010818949944}
+  m_Layer: 11
+  m_Name: EnemySphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1000010464106038
 GameObject:
   m_ObjectHideFlags: 1
@@ -1263,6 +1281,7 @@ Transform:
   m_Children:
   - {fileID: 4000012002237296}
   - {fileID: 4000013857347930}
+  - {fileID: 4000014114737130}
   m_Father: {fileID: 4000010962705722}
   m_RootOrder: 0
 --- !u!4 &4000012403275662
@@ -1646,6 +1665,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4000013201715552}
   m_RootOrder: 0
+--- !u!4 &4000014114737130
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010428899144}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -71.67212, y: -0.049999952, z: -53.239468}
+  m_LocalScale: {x: 2.9999998, y: 2.9999998, z: 2.9999998}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 4000012299954686}
+  m_RootOrder: 2
 --- !u!4 &4000014220453092
 Transform:
   m_ObjectHideFlags: 1
@@ -1674,6 +1706,42 @@ Transform:
   - {fileID: 4000012733069052}
   m_Father: {fileID: 4000010248286818}
   m_RootOrder: 1
+--- !u!23 &23000010818949944
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010428899144}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 037616029cc63044d888d6e67bad3137, type: 2}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!33 &33000014066670310
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010428899144}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!54 &54000011942700876
 Rigidbody:
   m_ObjectHideFlags: 1
@@ -1768,6 +1836,18 @@ MonoBehaviour:
   weapon: {fileID: 0}
   normalTexture: {fileID: 2800000, guid: bd9725feebe72475fa69d75181579cc0, type: 3}
   damagedTexture: {fileID: 2800000, guid: 96b5fc4d589404418a5e357fd83bb834, type: 3}
+--- !u!135 &135000012402957608
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010428899144}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!136 &136000012821376914
 CapsuleCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Units/UnitFreshmanStudent.prefab
+++ b/Assets/Prefabs/Units/UnitFreshmanStudent.prefab
@@ -1063,6 +1063,7 @@ Transform:
   m_Children:
   - {fileID: 4000012969237750}
   - {fileID: 4000010657185096}
+  - {fileID: 4000011762936028}
   m_Father: {fileID: 4000012803177534}
   m_RootOrder: 0
 --- !u!4 &4000010657185096
@@ -1075,8 +1076,7 @@ Transform:
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_Children:
-  - {fileID: 4000011762936028}
+  m_Children: []
   m_Father: {fileID: 4000010646470914}
   m_RootOrder: 1
 --- !u!4 &4000010754552364
@@ -1251,13 +1251,13 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000012152850164}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_LocalScale: {x: 2.9999998, y: 2.9999998, z: 2.9999998}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
-  m_Father: {fileID: 4000010657185096}
-  m_RootOrder: 0
+  m_Father: {fileID: 4000010646470914}
+  m_RootOrder: 2
 --- !u!4 &4000011808364834
 Transform:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Units/UnitFreshmanStudent.prefab
+++ b/Assets/Prefabs/Units/UnitFreshmanStudent.prefab
@@ -402,6 +402,24 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000012152850164
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000011762936028}
+  - 33: {fileID: 33000010704850932}
+  - 135: {fileID: 135000011487485290}
+  - 23: {fileID: 23000013172705804}
+  m_Layer: 11
+  m_Name: EnemySphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1000012348221706
 GameObject:
   m_ObjectHideFlags: 1
@@ -1057,7 +1075,8 @@ Transform:
   m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 0.99999994, y: 0.99999994, z: 0.99999994}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_Children: []
+  m_Children:
+  - {fileID: 4000011762936028}
   m_Father: {fileID: 4000010646470914}
   m_RootOrder: 1
 --- !u!4 &4000010754552364
@@ -1225,6 +1244,19 @@ Transform:
   m_Children:
   - {fileID: 4000010641755552}
   m_Father: {fileID: 4000012383595712}
+  m_RootOrder: 0
+--- !u!4 &4000011762936028
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012152850164}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 3}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 4000010657185096}
   m_RootOrder: 0
 --- !u!4 &4000011808364834
 Transform:
@@ -1673,6 +1705,42 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4000011808364834}
   m_RootOrder: 0
+--- !u!23 &23000013172705804
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012152850164}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 037616029cc63044d888d6e67bad3137, type: 2}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!33 &33000010704850932
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012152850164}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!54 &54000013453037300
 Rigidbody:
   m_ObjectHideFlags: 1
@@ -1767,6 +1835,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6f798caec2da5b74c8d81cdab3a9e80c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!135 &135000011487485290
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012152850164}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!136 &136000012314590818
 CapsuleCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Units/UnitJanitor.prefab
+++ b/Assets/Prefabs/Units/UnitJanitor.prefab
@@ -207,6 +207,24 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000011098858028
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000013182505636}
+  - 33: {fileID: 33000010157489576}
+  - 135: {fileID: 135000010912310334}
+  - 23: {fileID: 23000010229440988}
+  m_Layer: 11
+  m_Name: EnemySphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1000011114946404
 GameObject:
   m_ObjectHideFlags: 1
@@ -889,6 +907,7 @@ Transform:
   m_Children:
   - {fileID: 4000013558802204}
   - {fileID: 4000013755302608}
+  - {fileID: 4000013182505636}
   m_Father: {fileID: 4000011838502032}
   m_RootOrder: 0
 --- !u!4 &4000010148111720
@@ -1425,6 +1444,19 @@ Transform:
   - {fileID: 4000012534281292}
   m_Father: {fileID: 4000010485260694}
   m_RootOrder: 0
+--- !u!4 &4000013182505636
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011098858028}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -69.17212, y: -0.049999952, z: -53.239468}
+  m_LocalScale: {x: 2.9999998, y: 2.9999998, z: 2.9999998}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 4000010004646268}
+  m_RootOrder: 2
 --- !u!4 &4000013230545358
 Transform:
   m_ObjectHideFlags: 1
@@ -1673,6 +1705,42 @@ Transform:
   - {fileID: 4000011323395804}
   m_Father: {fileID: 4000012488467280}
   m_RootOrder: 4
+--- !u!23 &23000010229440988
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011098858028}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 037616029cc63044d888d6e67bad3137, type: 2}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!33 &33000010157489576
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011098858028}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!54 &54000010589195306
 Rigidbody:
   m_ObjectHideFlags: 1
@@ -1767,6 +1835,18 @@ MonoBehaviour:
   - {fileID: 1000012144391894, guid: ecf0109ef1d3ac6408373e89d3f53369, type: 2}
   proj_origin: {fileID: 1000011473136326}
   shootSound: {fileID: 8300000, guid: cf73db8e4891a754791d586816040dff, type: 3}
+--- !u!135 &135000010912310334
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011098858028}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!136 &136000011654396924
 CapsuleCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Units/UnitManifestant.prefab
+++ b/Assets/Prefabs/Units/UnitManifestant.prefab
@@ -86,6 +86,24 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000010279384398
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000012304579186}
+  - 33: {fileID: 33000013399956540}
+  - 135: {fileID: 135000012719723114}
+  - 23: {fileID: 23000010662862462}
+  m_Layer: 11
+  m_Name: EnemySphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1000010435179100
 GameObject:
   m_ObjectHideFlags: 1
@@ -1329,6 +1347,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4000013064673466}
   m_RootOrder: 0
+--- !u!4 &4000012304579186
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010279384398}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -64.17212, y: -0.049999952, z: -53.239468}
+  m_LocalScale: {x: 2.9999998, y: 2.9999998, z: 2.9999998}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 4000013245773386}
+  m_RootOrder: 2
 --- !u!4 &4000012344247198
 Transform:
   m_ObjectHideFlags: 1
@@ -1494,6 +1525,7 @@ Transform:
   m_Children:
   - {fileID: 4000012725627192}
   - {fileID: 4000011855192568}
+  - {fileID: 4000012304579186}
   m_Father: {fileID: 4000012530387730}
   m_RootOrder: 0
 --- !u!4 &4000013270848624
@@ -1673,6 +1705,42 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4000011756432538}
   m_RootOrder: 0
+--- !u!23 &23000010662862462
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010279384398}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 037616029cc63044d888d6e67bad3137, type: 2}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!33 &33000013399956540
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010279384398}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!54 &54000010577490724
 Rigidbody:
   m_ObjectHideFlags: 1
@@ -1767,6 +1835,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   TooltipText: {fileID: 0}
+--- !u!135 &135000012719723114
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010279384398}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!136 &136000011944132906
 CapsuleCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Units/UnitProfessor.prefab
+++ b/Assets/Prefabs/Units/UnitProfessor.prefab
@@ -326,6 +326,24 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000011280771266
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000013713381554}
+  - 33: {fileID: 33000013600408282}
+  - 135: {fileID: 135000011367321776}
+  - 23: {fileID: 23000013681672546}
+  m_Layer: 11
+  m_Name: EnemySphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1000011292150430
 GameObject:
   m_ObjectHideFlags: 1
@@ -1618,6 +1636,19 @@ Transform:
   - {fileID: 4000010037970022}
   m_Father: {fileID: 4000012458789636}
   m_RootOrder: 0
+--- !u!4 &4000013713381554
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011280771266}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -61.67212, y: -0.049999952, z: -53.239468}
+  m_LocalScale: {x: 2.9999998, y: 2.9999998, z: 2.9999998}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 4000014007041438}
+  m_RootOrder: 3
 --- !u!4 &4000014003814524
 Transform:
   m_ObjectHideFlags: 1
@@ -1646,6 +1677,7 @@ Transform:
   - {fileID: 4000013089403790}
   - {fileID: 4000013165661280}
   - {fileID: 4000010234578938}
+  - {fileID: 4000013713381554}
   m_Father: {fileID: 4000012971466140}
   m_RootOrder: 0
 --- !u!4 &4000014068695224
@@ -1704,6 +1736,35 @@ Transform:
   - {fileID: 4000014146361940}
   m_Father: {fileID: 4000014068695224}
   m_RootOrder: 0
+--- !u!23 &23000013681672546
+MeshRenderer:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011280771266}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 037616029cc63044d888d6e67bad3137, type: 2}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
 --- !u!23 &23000013905152884
 MeshRenderer:
   m_ObjectHideFlags: 1
@@ -1740,6 +1801,13 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000014136018310}
   m_Mesh: {fileID: 4300000, guid: 0a2346bc162f8f64eb05f37032a1ff42, type: 3}
+--- !u!33 &33000013600408282
+MeshFilter:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011280771266}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!54 &54000013255516602
 Rigidbody:
   m_ObjectHideFlags: 1
@@ -1834,6 +1902,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6f798caec2da5b74c8d81cdab3a9e80c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!135 &135000011367321776
+SphereCollider:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000011280771266}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!136 &136000010315116932
 CapsuleCollider:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Minimap.meta
+++ b/Assets/Scripts/Minimap.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 41051c6193f16f64f8c45f9521669fd1
+folderAsset: yes
+timeCreated: 1481060821
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Minimap/CameraFollow.cs
+++ b/Assets/Scripts/Minimap/CameraFollow.cs
@@ -1,0 +1,33 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+public class CameraFollow : MonoBehaviour {
+
+	public Transform Tarjet; // This will be the main camera (and minimap) position
+	
+
+
+	// Use this for initialization
+	void Start () {
+
+	}
+	
+	// Update is called once per frame
+	void Update () {
+
+	}
+	
+	// This function is called after all updates have been done
+	void LateUpdate(){
+		// Position:
+		transform.position = new Vector3(Tarjet.position.x, transform.position.y, Tarjet.position.z); // we set the x and z of our minimap camera equals to x and z of main manera
+		
+		// Orientation:
+		Vector3 eulerAngles = Tarjet.eulerAngles; // We copy the main camera horientarion
+		eulerAngles.x = 90; // We set the X orientation of out copy as 90 (perpendicular to terrain)
+		
+		transform.eulerAngles = eulerAngles; // we set the new orientation to our minimap camera
+	}
+	
+}

--- a/Assets/Scripts/Minimap/CameraFollow.cs.meta
+++ b/Assets/Scripts/Minimap/CameraFollow.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ce89bbe4477e11340b81a97eebadb692
+timeCreated: 1481060833
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MusicController.cs
+++ b/Assets/Scripts/MusicController.cs
@@ -16,6 +16,7 @@ public class MusicController : MonoBehaviour {
 	void Awake () {
 		AudioSource music = GetComponent<AudioSource>();
 		music.ignoreListenerVolume = true; // We make the audio source ignore the audio listener
+		music.volume = 0.5f;
 	}
 	
 }

--- a/Assets/TestScene/LightCameraTest.unity
+++ b/Assets/TestScene/LightCameraTest.unity
@@ -4135,6 +4135,53 @@ Transform:
   m_Children: []
   m_Father: {fileID: 423572303}
   m_RootOrder: 12
+--- !u!1001 &1105403823
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4000014048068682, guid: 10bcc405a3b05d741a42b45585c08586, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014048068682, guid: 10bcc405a3b05d741a42b45585c08586, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014048068682, guid: 10bcc405a3b05d741a42b45585c08586, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014048068682, guid: 10bcc405a3b05d741a42b45585c08586, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014048068682, guid: 10bcc405a3b05d741a42b45585c08586, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014048068682, guid: 10bcc405a3b05d741a42b45585c08586, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014048068682, guid: 10bcc405a3b05d741a42b45585c08586, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4000014048068682, guid: 10bcc405a3b05d741a42b45585c08586, type: 2}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000010097744786, guid: 10bcc405a3b05d741a42b45585c08586,
+        type: 2}
+      propertyPath: Tarjet
+      value: 
+      objectReference: {fileID: 1864657049}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 10bcc405a3b05d741a42b45585c08586, type: 2}
+  m_IsPrefabParent: 0
 --- !u!4 &1108032061 stripped
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 5e7e4a46119ad774b91921b4751121ce, type: 3}
@@ -7123,6 +7170,11 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1857121411}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1864657049 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4000012445027732, guid: dc0d54ea4544dfd419444fd2c520eb25,
+    type: 2}
+  m_PrefabInternal: {fileID: 669233176}
 --- !u!1001 &1864995162
 Prefab:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -26,7 +26,7 @@ TagManager:
   - Buildings
   - Terrain
   - Grid
-  - 
+  - Minimap
   - 
   - 
   - 


### PR DESCRIPTION
Primera version del minimapa:
![minmap](https://cloud.githubusercontent.com/assets/9854667/20945841/0d5e5b54-bc09-11e6-8284-9ad420111577.PNG)

El minimap muestra el terreno en vista aérea, y se mueve y rota segun la cámara principal.
Nuestra ubicación se muestra con un circulo azul, la de les enemigos con circulos rojos.
Para esto último se ha modificado el prefab de main camera y el de Freshman.

Aún puede ser modificado, y falta integrarlo para el hud. No se ha modificado la escena, por tanto hace falta arrastrar el prefab del minimap para verlo.