### PR TITLE
Towers remake

### DIFF
--- a/Assets/Prefabs/Towers/Tower.prefab
+++ b/Assets/Prefabs/Towers/Tower.prefab
@@ -11,25 +11,6 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 1000011397538348}
   m_IsPrefabParent: 1
---- !u!1 &1000010893995726
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 4000013186379108}
-  - 33: {fileID: 33000013261260516}
-  - 23: {fileID: 23000012569671148}
-  - 95: {fileID: 95000012390861510}
-  - 64: {fileID: 64000014029813626}
-  m_Layer: 8
-  m_Name: TowerModel
-  m_TagString: Tower
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &1000011089548668
 GameObject:
   m_ObjectHideFlags: 0
@@ -65,6 +46,25 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000011920009446
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000013260330046}
+  - 33: {fileID: 33000013366810396}
+  - 23: {fileID: 23000010634503696}
+  - 95: {fileID: 95000013967128378}
+  - 64: {fileID: 64000011750119744}
+  m_Layer: 8
+  m_Name: TowerModel
+  m_TagString: Tower
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1000012882011190
 GameObject:
   m_ObjectHideFlags: 0
@@ -92,7 +92,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1.0000004}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 4000013186379108}
+  - {fileID: 4000013260330046}
   - {fileID: 4000011863964682}
   - {fileID: 4000013693324336}
   m_Father: {fileID: 0}
@@ -110,14 +110,14 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4000011410470234}
   m_RootOrder: 1
---- !u!4 &4000013186379108
+--- !u!4 &4000013260330046
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000010893995726}
+  m_GameObject: {fileID: 1000011920009446}
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 3, y: 3, z: 1}
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
   m_Children: []
@@ -136,12 +136,12 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4000011410470234}
   m_RootOrder: 2
---- !u!23 &23000012569671148
+--- !u!23 &23000010634503696
 MeshRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000010893995726}
+  m_GameObject: {fileID: 1000011920009446}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -149,8 +149,8 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 2100000, guid: 74712f49717b2ed4b9bd0d60b950d249, type: 2}
-  - {fileID: 2100000, guid: b625a0dc08f227f47a31457f3e4be85f, type: 2}
+  - {fileID: 2100000, guid: 34e8f1722e37c8b4fb94e19ff4d8a4c7, type: 2}
+  - {fileID: 2100000, guid: 5680b6a93d56a0941a39303115c678ed, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
@@ -166,13 +166,13 @@ MeshRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingOrder: 0
---- !u!33 &33000013261260516
+--- !u!33 &33000013366810396
 MeshFilter:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000010893995726}
-  m_Mesh: {fileID: 4300000, guid: 791bdb27c1bbc6b46b97929351d80d32, type: 3}
+  m_GameObject: {fileID: 1000011920009446}
+  m_Mesh: {fileID: 4300000, guid: 9e591d50b547a43ca9f5460eaf3aa702, type: 3}
 --- !u!54 &54000010725431262
 Rigidbody:
   m_ObjectHideFlags: 1
@@ -188,18 +188,18 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!64 &64000014029813626
+--- !u!64 &64000011750119744
 MeshCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000010893995726}
+  m_GameObject: {fileID: 1000011920009446}
   m_Material: {fileID: 0}
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
   m_Convex: 1
-  m_Mesh: {fileID: 4300000, guid: 791bdb27c1bbc6b46b97929351d80d32, type: 3}
+  m_Mesh: {fileID: 4300000, guid: 9e591d50b547a43ca9f5460eaf3aa702, type: 3}
 --- !u!82 &82000012240276802
 AudioSource:
   m_ObjectHideFlags: 1
@@ -275,15 +275,15 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
---- !u!95 &95000012390861510
+--- !u!95 &95000013967128378
 Animator:
   serializedVersion: 3
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000010893995726}
+  m_GameObject: {fileID: 1000011920009446}
   m_Enabled: 0
-  m_Avatar: {fileID: 9000000, guid: 791bdb27c1bbc6b46b97929351d80d32, type: 3}
+  m_Avatar: {fileID: 9000000, guid: 9e591d50b547a43ca9f5460eaf3aa702, type: 3}
   m_Controller: {fileID: 0}
   m_CullingMode: 0
   m_UpdateMode: 0
@@ -329,6 +329,10 @@ MonoBehaviour:
   source: {fileID: 82000012240276802}
   buy: {fileID: 8300000, guid: 04a82c36a813afe44ab7c0cfb6501fd2, type: 3}
   upgrade: {fileID: 8300000, guid: f9b40b600feb9d84daadfd39dda46999, type: 3}
+  textures:
+  - {fileID: 2800000, guid: f5f8ff9c7d05a4583bd371c812373b86, type: 3}
+  - {fileID: 2800000, guid: 4d3fac93c6ed74ccda09ffa16c7cbbdf, type: 3}
+  - {fileID: 2800000, guid: 0b116123907e946a6828c591647618c0, type: 3}
 --- !u!114 &114000014177185980
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Towers/TowerShadow.prefab
+++ b/Assets/Prefabs/Towers/TowerShadow.prefab
@@ -11,24 +11,6 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 1000011985423730}
   m_IsPrefabParent: 1
---- !u!1 &1000011560806714
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
-  m_Component:
-  - 4: {fileID: 4000011552424362}
-  - 33: {fileID: 33000010345177424}
-  - 23: {fileID: 23000010191093316}
-  - 95: {fileID: 95000010373815810}
-  m_Layer: 0
-  m_Name: TowerModel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &1000011985423730
 GameObject:
   m_ObjectHideFlags: 0
@@ -45,6 +27,24 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &1000014091596472
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000013536641330}
+  - 33: {fileID: 33000012559522104}
+  - 23: {fileID: 23000012138289828}
+  - 95: {fileID: 95000011870413036}
+  m_Layer: 0
+  m_Name: TowerModel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!4 &4000010545440826
 Transform:
   m_ObjectHideFlags: 1
@@ -56,28 +56,28 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1.0000004}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 4000011552424362}
+  - {fileID: 4000013536641330}
   m_Father: {fileID: 0}
   m_RootOrder: 0
---- !u!4 &4000011552424362
+--- !u!4 &4000013536641330
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011560806714}
+  m_GameObject: {fileID: 1000014091596472}
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 3, y: 3, z: 1}
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010545440826}
   m_RootOrder: 0
---- !u!23 &23000010191093316
+--- !u!23 &23000012138289828
 MeshRenderer:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011560806714}
+  m_GameObject: {fileID: 1000014091596472}
   m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -85,8 +85,8 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 2100000, guid: 74712f49717b2ed4b9bd0d60b950d249, type: 2}
-  - {fileID: 2100000, guid: b625a0dc08f227f47a31457f3e4be85f, type: 2}
+  - {fileID: 2100000, guid: 34e8f1722e37c8b4fb94e19ff4d8a4c7, type: 2}
+  - {fileID: 2100000, guid: 5680b6a93d56a0941a39303115c678ed, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
@@ -102,13 +102,13 @@ MeshRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingOrder: 0
---- !u!33 &33000010345177424
+--- !u!33 &33000012559522104
 MeshFilter:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011560806714}
-  m_Mesh: {fileID: 4300000, guid: 791bdb27c1bbc6b46b97929351d80d32, type: 3}
+  m_GameObject: {fileID: 1000014091596472}
+  m_Mesh: {fileID: 4300000, guid: 9e591d50b547a43ca9f5460eaf3aa702, type: 3}
 --- !u!54 &54000011361588006
 Rigidbody:
   m_ObjectHideFlags: 1
@@ -124,15 +124,15 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!95 &95000010373815810
+--- !u!95 &95000011870413036
 Animator:
   serializedVersion: 3
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1000011560806714}
+  m_GameObject: {fileID: 1000014091596472}
   m_Enabled: 0
-  m_Avatar: {fileID: 9000000, guid: 791bdb27c1bbc6b46b97929351d80d32, type: 3}
+  m_Avatar: {fileID: 9000000, guid: 9e591d50b547a43ca9f5460eaf3aa702, type: 3}
   m_Controller: {fileID: 0}
   m_CullingMode: 0
   m_UpdateMode: 0

--- a/Assets/Prefabs/Towers/TowerShadow.prefab
+++ b/Assets/Prefabs/Towers/TowerShadow.prefab
@@ -67,7 +67,7 @@ Transform:
   m_GameObject: {fileID: 1000014091596472}
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 3, y: 3, z: 1}
+  m_LocalScale: {x: 3, y: 3, z: 0.5}
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 4000010545440826}

--- a/Assets/Scripts/Model/Building.cs
+++ b/Assets/Scripts/Model/Building.cs
@@ -26,7 +26,6 @@ public class Building : MonoBehaviour, CanUpgrade, CanReceiveDamage, HUDSubject
     private MeshRenderer skin;
     //textures to apply on each level
     public List<Texture> textures;
-    public Texture[][] tx;
     private GameObject smokeEffect;
     private ParticleSystem smoke;
     // Receive damage by weapon

--- a/Assets/Scripts/Model/Tower.cs
+++ b/Assets/Scripts/Model/Tower.cs
@@ -1,4 +1,7 @@
 ﻿using UnityEngine;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 
 public class Tower : MonoBehaviour, CanUpgrade, HUDSubject
 {
@@ -13,6 +16,9 @@ public class Tower : MonoBehaviour, CanUpgrade, HUDSubject
     public AudioClip buy, upgrade;
 
     private GameObject model;
+    private MeshRenderer skin;
+    public List<Texture> textures;
+
     public bool IsUpgradeable(int numCoins)
     {
         return (upgradeCost <= numCoins ) && (currentLevel < maxLevel);
@@ -27,6 +33,7 @@ public class Tower : MonoBehaviour, CanUpgrade, HUDSubject
 		weapon.setProjectile (currentLevel);
 		NotifyHUD();
         ApplyMainModelScale();
+        ApplyMainTexture();
         //Sound
         if (!source.isPlaying)
             source.PlayOneShot(upgrade);
@@ -55,7 +62,10 @@ public class Tower : MonoBehaviour, CanUpgrade, HUDSubject
         weapon = gameObject.GetComponent<Weapon>();
         //Put towermodel on scale of 0.5 for first level
         model = transform.FindChild("TowerModel").gameObject;
-        model.transform.localScale = new Vector3(model.transform.localScale.x, model.transform.localScale.y, 0.5f);	
+        model.transform.localScale = new Vector3(model.transform.localScale.x, model.transform.localScale.y, 0.5f);
+        //texture data
+        skin = model.GetComponent<MeshRenderer>();
+        skin.material.mainTexture = textures[currentLevel - 1];
         //Sound
         if (!source.isPlaying)
             source.PlayOneShot(buy);
@@ -96,5 +106,10 @@ public class Tower : MonoBehaviour, CanUpgrade, HUDSubject
                 break;
             default: break;
         }
+    }
+
+    public void ApplyMainTexture()
+    {
+        skin.material.mainTexture = textures[currentLevel - 1];
     }
 }


### PR DESCRIPTION
Make tower prefabs use new tower models and textures
At each level tower changes its size
Level 1 - 0.5
Level 2 - 0.8
Level 3 - 1.0
(this was made in #335  )
At each level tower changes its texture 
Bacause we have only textures for low life , mid life and full life (i dont know where it came from; towers cannot be damaged) i use
Lowlife texture at level 1, midlife at level 2 and fulllife at level 3
Also changed tower size when placing new towers (to z = 0.5)