### PR TITLE
TooltipText initialization Fixed

### DIFF
--- a/Assets/Prefabs/GameMenu.prefab
+++ b/Assets/Prefabs/GameMenu.prefab
@@ -1820,7 +1820,6 @@ MonoBehaviour:
   soundLow: {fileID: 21300000, guid: 4410bc3d092483d4286562365a1d12c1, type: 3}
   soundMedium: {fileID: 21300000, guid: e0aa23d3740e7ee40a40fad3c1995587, type: 3}
   soundMuted: {fileID: 21300000, guid: 22844fa233958aa478460489cf91089f, type: 3}
-  TooltipText: {fileID: 0}
   volumeSlider: {fileID: 114000012409637798}
 --- !u!114 &114000014218798140
 MonoBehaviour:

--- a/Assets/Scripts/UIManager.cs
+++ b/Assets/Scripts/UIManager.cs
@@ -24,7 +24,7 @@ public class UIManager : MonoBehaviour
     public Sprite soundMuted;
 
     // Text field that will show the tooltip:
-    public Text TooltipText;
+    private Text TooltipText;
 
     // Control of volume:
     public Slider volumeSlider;
@@ -44,6 +44,8 @@ public class UIManager : MonoBehaviour
         musicSlider.value = PersistentValues.musicVolume;
         lastMVolume = PersistentValues.musicLastVolume;
         lastEVolume = PersistentValues.effectsLastVolume;
+		
+		TooltipText = GameObject.Find("FeedbackText").GetComponent<Text>();
     }
 
     // Update is called once per frame


### PR DESCRIPTION
La variable TooltipText del menú de pausa no estaba inicializada, debido al reciente cambio de esta (se movió de un prefab a otro).
Se ha inicializado desde script.

Issue:
https://github.com/NestorTejero/ES2016B/issues/370