### PR TITLE
Minimap has a natural position now, and main camera is not shown in it.

### DIFF
--- a/Assets/Prefabs/GridRelated/Grid+Camera.prefab
+++ b/Assets/Prefabs/GridRelated/Grid+Camera.prefab
@@ -179,7 +179,7 @@ MeshRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1000012453651090}
-  m_Enabled: 1
+  m_Enabled: 0
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_MotionVectors: 0
@@ -306,8 +306,8 @@ MonoBehaviour:
     panSmooth: 7
     zoomSmoth: 5
     zoomStep: 5
-  scrollZone: 30
   scrollSpeed: 200
+  scrollZone: 30
 --- !u!114 &114000013528213974
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Minimap/Minimap.prefab
+++ b/Assets/Prefabs/Minimap/Minimap.prefab
@@ -104,6 +104,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Tarjet: {fileID: 0}
+  mask:
+    serializedVersion: 2
+    m_Bits: 512
 --- !u!124 &124000011548431216
 Behaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Minimap/CameraFollow.cs
+++ b/Assets/Scripts/Minimap/CameraFollow.cs
@@ -1,8 +1,10 @@
 ﻿using UnityEngine;
+using System;
 
 public class CameraFollow : MonoBehaviour
 {
     public Transform Tarjet; // This will be the main camera (and minimap) position
+	public LayerMask mask;
 
 
     // Use this for initialization
@@ -18,14 +20,44 @@ public class CameraFollow : MonoBehaviour
     // This function is called after all updates have been done
     private void LateUpdate()
     {
-        // Position:
-        transform.position = new Vector3(Tarjet.position.x, transform.position.y, Tarjet.position.z);
+        setMinimapPosition();
+		setMinimapOrientation();
+		
+    }
+	
+	private void setMinimapPosition(){
+		// Old Position (we dont delete this to understand what we did later):
+        //transform.position = new Vector3(Tarjet.position.x, transform.position.y, Tarjet.position.z);
         // we set the x and z of our minimap camera equals to x and z of main manera
+		
+		
+		// New Position:
+		RaycastHit hit;
+        var ray = new Ray(Tarjet.position, Tarjet.forward);
 
-        // Orientation:
+        if (Physics.Raycast(ray, out hit,150, mask))
+        {
+            transform.position = new Vector3((int) hit.point.x, transform.position.y, (int) hit.point.z);
+        }
+		
+		// Para conseguir una posición del minimapa más natural, en lugar de coger directamente la X y Z de cámara, hacemos un raycast,
+		// y cogemos la interesección con el terreno de juego.
+		// la variable mask nos sirve para que el raycast solo tenga en cuenta el terreno.
+		
+		
+		/* Raycast alternativo
+		RaycastHit[] hit;
+		hit = Physics.RaycastAll(Tarjet.position, Tarjet.forward, 200);
+		RaycastHit last = hit[hit.Length -1];
+		transform.position = new Vector3((int) (last.point.x), transform.position.y, (int) (last.point.z));
+		*/
+	}
+	
+	private void setMinimapOrientation(){
+		// Orientation:
         var eulerAngles = Tarjet.eulerAngles; // We copy the main camera horientarion
         eulerAngles.x = 90; // We set the X orientation of out copy as 90 (perpendicular to terrain)
 
         transform.eulerAngles = eulerAngles; // we set the new orientation to our minimap camera
-    }
+	}
 }


### PR DESCRIPTION
![newminimap](https://cloud.githubusercontent.com/assets/9854667/21295788/e6ecd150-c55c-11e6-9a73-30452cb7f9ee.PNG)

El minimapa ya no queda centrado en la posición de la càmara, sinó en el corte del raycast de esta con el terreno, quedando un poco más "avanzado".
La posición de la cámara principal ya no se muestra como un punto azul. (Puede volver a mostrarse con un par de clicks)

Issue:
https://github.com/NestorTejero/ES2016B/issues/368